### PR TITLE
 dataHandle: Rename 'Read' to 'ReadAll'

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -1011,6 +1011,6 @@ type dataHandle struct {
 	data []byte
 }
 
-func (d *dataHandle) Read(intr Intr) ([]byte, Error) {
+func (d *dataHandle) ReadAll(intr Intr) ([]byte, Error) {
 	return d.data, nil
 }


### PR DESCRIPTION
Because of this naming mismatch, dataHandle didn't actually implement
any Read method, rendering it unusable.
