### PR TITLE
Remove setattr logging statement

### DIFF
--- a/fs/serve.go
+++ b/fs/serve.go
@@ -527,7 +527,6 @@ func (c *serveConn) serve(fs FS, r fuse.Request) {
 			}
 		}
 
-		log.Printf("setattr %v", r)
 		if n, ok := node.(NodeSetattrer); ok {
 			if err := n.Setattr(r, s, intr); err != nil {
 				done(err)


### PR DESCRIPTION
Given that no other operation prints anything except on errors, setattr also should not do this.
