### PR TITLE
OS X: Fix kernel connection closing on writes > 8128 bytes

### DIFF
--- a/mount_darwin.go
+++ b/mount_darwin.go
@@ -54,6 +54,8 @@ func callMount(dir string, f *os.File, ready chan<- struct{}, errp *error) error
 	bin := "/Library/Filesystems/osxfusefs.fs/Support/mount_osxfusefs"
 	cmd := exec.Command(
 		bin,
+		"-o",
+		"iosize=4096",
 		// refers to fd passed in cmd.ExtraFiles
 		"3",
 		dir,


### PR DESCRIPTION
This restores the mount_osxfusefs command from before the OS X mount
rewrite and sets iosize=4096. I have no idea why this option is
required, but it makes the connection not break.

This actually was the I/O error from #11, `git clone` this time died with

```
fatal: write error: Input/output error
fatal: index-pack failed
```

When this happens, `Conn.ReadRequest` returns an io.EOF error and Serve stops the loop.

Using `git bisect` I found dfc88d4ea5c77ec8b03401ca7404fe58abb8b9a1 was the first commit having this issue.

In case you can't reproduce the problem, I'll try to build a minimal filesystem showing the problem.
