### PR TITLE
Prevent build on unsupported OSes.

### DIFF
--- a/error_std.go
+++ b/error_std.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,linux
 
 package fuse
 

--- a/fs/fstestutil/mounted.go
+++ b/fs/fstestutil/mounted.go
@@ -1,14 +1,17 @@
+// +build linux darwin
+
 package fstestutil
 
 import (
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
 	"errors"
 	"io/ioutil"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
 )
 
 // Mount contains information about the mount for the test to use.

--- a/fs/fstestutil/record/buffer.go
+++ b/fs/fstestutil/record/buffer.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package record
 
 import (

--- a/fs/fstestutil/record/record.go
+++ b/fs/fstestutil/record/record.go
@@ -1,10 +1,13 @@
+// +build linux darwin
+
 package record
 
 import (
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
 	"sync"
 	"sync/atomic"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
 )
 
 // Writes gathers data from FUSE Write calls.

--- a/fs/fstestutil/record/wait.go
+++ b/fs/fstestutil/record/wait.go
@@ -1,10 +1,13 @@
+// +build linux darwin
+
 package record
 
 import (
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
 	"sync"
 	"time"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
 )
 
 type nothing struct{}

--- a/fs/serve.go
+++ b/fs/serve.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 // FUSE service loop, for servers that wish to use it.
 
 package fs

--- a/fs/serve_test.go
+++ b/fs/serve_test.go
@@ -1,12 +1,8 @@
+// +build linux darwin
+
 package fs_test
 
 import (
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
-	"bazil.org/fuse/fs/fstestutil"
-	"bazil.org/fuse/fs/fstestutil/record"
-	"bazil.org/fuse/fuseutil"
-	"bazil.org/fuse/syscallx"
 	"io/ioutil"
 	"log"
 	"os"
@@ -15,6 +11,13 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"bazil.org/fuse/fs/fstestutil"
+	"bazil.org/fuse/fs/fstestutil/record"
+	"bazil.org/fuse/fuseutil"
+	"bazil.org/fuse/syscallx"
 )
 
 // TO TEST:

--- a/fs/tree.go
+++ b/fs/tree.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 // FUSE directory tree, for servers that wish to use it with the service loop.
 
 package fs

--- a/fuse.go
+++ b/fuse.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 // See the file LICENSE for copyright and licensing information.
 // Adapted from Plan 9 from User Space's src/cmd/9pfuse/fuse.c,
 // which carries this notice:

--- a/fuse_kernel.go
+++ b/fuse_kernel.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 // See the file LICENSE for copyright and licensing information.
 
 // Derived from FUSE's fuse_kernel.h

--- a/fuseutil/fuseutil.go
+++ b/fuseutil/fuseutil.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package fuseutil
 
 import (

--- a/hellofs/hello.go
+++ b/hellofs/hello.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 // Hellofs implements a simple "hello world" file system.
 package main
 

--- a/syscallx/syscallx_std.go
+++ b/syscallx/syscallx_std.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,linux
 
 package syscallx
 


### PR DESCRIPTION
This limits the build to explicitly listed OSes.  This makes it easier to
import bazil.org/fuse in projects that support more OSes than bazil.org/fuse.
For an example of why this is helpful, see https://camlistore.org/r/2056

Tested with:
$ GOOS=freebsd go build -v bazil.org/fuse/...
bazil.org/fuse
bazil.org/fuse/syscallx
bazil.org/fuse/fs/fstestutil
$ GOOS=linux go build -v bazil.org/fuse/...
bazil.org/fuse
bazil.org/fuse/syscallx
bazil.org/fuse/fuseutil
bazil.org/fuse/fs
bazil.org/fuse/fs/fstestutil
bazil.org/fuse/fs/fstestutil/record
bazil.org/fuse/hellofs
$ GOOS=darwin go build -v bazil.org/fuse/...
bazil.org/fuse
bazil.org/fuse/syscallx
bazil.org/fuse/fuseutil
bazil.org/fuse/fs
bazil.org/fuse/fs/fstestutil
bazil.org/fuse/fs/fstestutil/record
bazil.org/fuse/hellofs
