### PR TITLE
fix data race in reading Fd and Close of device os.File

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -103,6 +103,7 @@ type Conn struct {
 	MountError error
 
 	dev *os.File
+	fd  int
 	buf []byte
 	wio sync.Mutex
 }
@@ -128,6 +129,7 @@ func Mount(dir string) (*Conn, error) {
 		return nil, err
 	}
 	c.dev = f
+	c.fd = int(f.Fd())
 	return c, nil
 }
 
@@ -368,15 +370,11 @@ func (c *Conn) Close() error {
 	return c.dev.Close()
 }
 
-func (c *Conn) fd() int {
-	return int(c.dev.Fd())
-}
-
 func (c *Conn) ReadRequest() (Request, error) {
 	// TODO: Some kind of buffer reuse.
 	m := newMessage(c)
 loop:
-	n, err := syscall.Read(c.fd(), m.buf)
+	n, err := syscall.Read(c.fd, m.buf)
 	if err == syscall.EINTR {
 		// OSXFUSE sends EINTR to userspace when a request interrupt
 		// completed before it got sent to userspace?
@@ -839,7 +837,7 @@ func (c *Conn) respond(out *outHeader, n uintptr) {
 	defer c.wio.Unlock()
 	out.Len = uint32(n)
 	msg := (*[1 << 30]byte)(unsafe.Pointer(out))[:n]
-	nn, err := syscall.Write(c.fd(), msg)
+	nn, err := syscall.Write(c.fd, msg)
 	if nn != len(msg) || err != nil {
 		Debug(bugShortKernelWrite{
 			Written: int64(nn),
@@ -858,7 +856,7 @@ func (c *Conn) respondData(out *outHeader, n uintptr, data []byte) {
 	msg := make([]byte, out.Len)
 	copy(msg, (*[1 << 30]byte)(unsafe.Pointer(out))[:n])
 	copy(msg[n:], data)
-	syscall.Write(c.fd(), msg)
+	syscall.Write(c.fd, msg)
 }
 
 // An InitRequest is the first request sent on a FUSE file system.


### PR DESCRIPTION
specifically running my application with `-race` showed this:

```
==================
WARNING: DATA RACE
Write by goroutine 25:
  os.(*file).close()
      /usr/local/Cellar/go/1.3/libexec/src/pkg/os/file_unix.go:108 +0x19b
  os.(*File).Close()
      /usr/local/Cellar/go/1.3/libexec/src/pkg/os/file_unix.go:97 +0x94
  bazil.org/fuse.(*Conn).Close()
      /go/src/bazil.org/fuse/fuse.go:368 +0x5d
  ...

Previous read by goroutine 37:
  bazil.org/fuse.(*Conn).fd()
      /go/src/bazil.org/fuse/fuse.go:372 +0x80
  bazil.org/fuse.(*Conn).respond()
      /go/src/bazil.org/fuse/fuse.go:842 +0xdf
  bazil.org/fuse.(*DestroyRequest).Respond()
      /go/src/bazil.org/fuse/fuse.go:1431 +0xce
  bazil.org/fuse/fs.(*serveConn).serve()
      /go/src/bazil.org/fuse/fs/serve.go:1168 +0xb8b
```

Since the fd never changes, reading it once on initialization seems sufficient.
