### PR TITLE
Add nonempty mount option

### DIFF
--- a/mount_linux.go
+++ b/mount_linux.go
@@ -19,7 +19,7 @@ func mount(dir string, ready chan<- struct{}, errp *error) (fusefd *os.File, err
 	defer syscall.Close(fds[0])
 	defer syscall.Close(fds[1])
 
-	cmd := exec.Command("fusermount", "--", dir)
+	cmd := exec.Command("fusermount", "-o", "nonempty", "--", dir)
 	cmd.Env = append(os.Environ(), "_FUSE_COMMFD=3")
 
 	writeFile := os.NewFile(uintptr(fds[0]), "fusermount-child-writes")


### PR DESCRIPTION
# Fixes error when attempting to mount at a non-empty directory

Fixes the following issue:

`alphafusermount: "fusermount: mountpoint is not empty
fusermount: if you are sure this is safe, use the 'nonempty' mount option
exit status 1`
