### PR TITLE
Drop extraneous new line on Statfs debug print

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -1003,7 +1003,7 @@ type StatfsRequest struct {
 var _ = Request(&StatfsRequest{})
 
 func (r *StatfsRequest) String() string {
-	return fmt.Sprintf("Statfs [%s]\n", &r.Header)
+	return fmt.Sprintf("Statfs [%s]", &r.Header)
 }
 
 // Respond replies to the request with the given response.


### PR DESCRIPTION
There's an extraneous newline on the Statfs debug print.  Here's a tiny patch which removes it.  If you'd prefer a format-patch via email, I'll be happy to format the submission in that way.  If you require any other documentation, just ask.
