### PR TITLE
Add context.Context to the Debug reporting method, and all serving/response handling.

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -2,6 +2,8 @@ package fuse
 
 import (
 	"runtime"
+
+	"golang.org/x/net/context"
 )
 
 func stack() string {
@@ -9,7 +11,7 @@ func stack() string {
 	return string(buf[:runtime.Stack(buf, false)])
 }
 
-func nop(msg interface{}) {}
+func nop(ctx context.Context, msg interface{}) {}
 
 // Debug is called to output debug messages, including protocol
 // traces. The default behavior is to do nothing.
@@ -18,4 +20,4 @@ func nop(msg interface{}) {}
 // safe to marshal to JSON.
 //
 // Implementations must not retain msg.
-var Debug func(msg interface{}) = nop
+var Debug func(ctx context.Context, msg interface{}) = nop

--- a/fs/fstestutil/debug.go
+++ b/fs/fstestutil/debug.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"bazil.org/fuse"
+	"golang.org/x/net/context"
 )
 
 type flagDebug bool
@@ -18,7 +19,7 @@ func (f *flagDebug) IsBoolFlag() bool {
 	return true
 }
 
-func nop(msg interface{}) {}
+func nop(ctx context.Context, msg interface{}) {}
 
 func (f *flagDebug) Set(s string) error {
 	v, err := strconv.ParseBool(s)
@@ -38,7 +39,7 @@ func (f *flagDebug) String() string {
 	return strconv.FormatBool(bool(*f))
 }
 
-func logMsg(msg interface{}) {
+func logMsg(ctx context.Context, msg interface{}) {
 	log.Printf("FUSE: %s\n", msg)
 }
 

--- a/fs/fstestutil/mounted.go
+++ b/fs/fstestutil/mounted.go
@@ -10,6 +10,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
+	"golang.org/x/net/context"
 )
 
 // Mount contains information about the mount for the test to use.
@@ -75,7 +76,7 @@ func Mounted(srv *fs.Server, options ...fuse.MountOption) (*Mount, error) {
 	}
 	go func() {
 		defer close(done)
-		serveErr <- srv.Serve(c)
+		serveErr <- srv.Serve(context.Background(), c)
 	}()
 
 	select {
@@ -105,7 +106,7 @@ func MountedT(t testing.TB, filesys fs.FS, options ...fuse.MountOption) (*Mount,
 		FS: filesys,
 	}
 	if debug {
-		srv.Debug = func(msg interface{}) {
+		srv.Debug = func(ctx context.Context, msg interface{}) {
 			t.Logf("FUSE: %s", msg)
 		}
 	}

--- a/hellofs/hello.go
+++ b/hellofs/hello.go
@@ -41,7 +41,7 @@ func main() {
 	}
 	defer c.Close()
 
-	err = fs.Serve(c, FS{})
+	err = fs.Serve(context.Background(), c, FS{})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
context.Context is useful for tracing, time limiting, and connecting to external systems. Further the use of it by adding to Debug and then all methods that lead to Debug.

This, as a by-product, results in the ability to provide a surrounding Context to Serve(); which previously insisted on Background, making it a better part of a surrounding application.