### PR TITLE
Fixed a double-close bug in mount on Linux.

### DIFF
--- a/mount_linux.go
+++ b/mount_linux.go
@@ -40,8 +40,12 @@ func mount(dir string, conf *MountConfig, ready chan<- struct{}, errp *error) (f
 	if err != nil {
 		return nil, fmt.Errorf("socketpair error: %v", err)
 	}
-	defer syscall.Close(fds[0])
-	defer syscall.Close(fds[1])
+
+	writeFile := os.NewFile(uintptr(fds[0]), "fusermount-child-writes")
+	defer writeFile.Close()
+
+	readFile := os.NewFile(uintptr(fds[1]), "fusermount-parent-reads")
+	defer readFile.Close()
 
 	cmd := exec.Command(
 		"fusermount",
@@ -51,8 +55,6 @@ func mount(dir string, conf *MountConfig, ready chan<- struct{}, errp *error) (f
 	)
 	cmd.Env = append(os.Environ(), "_FUSE_COMMFD=3")
 
-	writeFile := os.NewFile(uintptr(fds[0]), "fusermount-child-writes")
-	defer writeFile.Close()
 	cmd.ExtraFiles = []*os.File{writeFile}
 
 	var wg sync.WaitGroup
@@ -76,8 +78,6 @@ func mount(dir string, conf *MountConfig, ready chan<- struct{}, errp *error) (f
 		return nil, fmt.Errorf("fusermount: %v", err)
 	}
 
-	readFile := os.NewFile(uintptr(fds[1]), "fusermount-parent-reads")
-	defer readFile.Close()
 	c, err := net.FileConn(readFile)
 	if err != nil {
 		return nil, fmt.Errorf("FileConn from fusermount socket: %v", err)


### PR DESCRIPTION
The socket file descriptors were previously closed by both a direct call
to syscall.Close and by a deferred call to os.File.Close. Now we close
them only once.

In the common case this would result in error EBADF from the second pair
of calls, which was ignored. However, there was a race that would come
up when the process was quite busy, especially with GOMAXPROCS > 1:

 *  Goroutine 1: mount does File.Close(4).
 *  Goroutine 2: os.Open returns a file with Fd() == 4.
 *  Goroutine 1: mount does syscall.Close(4)
 *  Goroutine 2: Interacting with the new file always returns EBADF.

I discovered this when attempting to parallelize a set of tests that
make heavy use of fuse. The double-close caused chaos, with EBADF errors
all over the place in unlikely situations. After staring at strace
output for a long time, I figured out this is what was happening.