### PR TITLE
Update HandleReadDirer to HandleReadDirAller in documentation

### DIFF
--- a/fs/serve.go
+++ b/fs/serve.go
@@ -254,7 +254,7 @@ func nodeAttr(ctx context.Context, n Node, attr *fuse.Attr) error {
 //
 // Other FUSE requests can be handled by implementing methods from the
 // Handle* interfaces. The most common to implement are HandleReader,
-// HandleReadDirer, and HandleWriter.
+// HandleReadDirAller, and HandleWriter.
 //
 // TODO implement methods: Getlk, Setlk, Setlkw
 type Handle interface {


### PR DESCRIPTION
HandleReadDirer has been renamed to HandleReadDirAller in 76147e705430bca787c46f858225f6052abfd920

ps. It would also be nice if you update the article [here](http://blog.gopheracademy.com/advent-2014/fuse-zipfs/) to reflect the changes.