### PR TITLE
Add OpenBSD support

### DIFF
--- a/error_bsd.go
+++ b/error_bsd.go
@@ -1,3 +1,5 @@
+// +build openbsd freebsd
+
 package fuse
 
 import "syscall"

--- a/fuse.go
+++ b/fuse.go
@@ -194,7 +194,7 @@ func initMount(c *Conn, conf *mountConfig) error {
 
 	min := Protocol{protoVersionMinMajor, protoVersionMinMinor}
 	if r.Kernel.LT(min) {
-		req.RespondError(Errno(syscall.EPROTO))
+		req.RespondError(Errno(syscall.EIO))
 		c.Close()
 		return &OldVersionError{
 			Kernel:     r.Kernel,

--- a/fuse_kernel_bsd.go
+++ b/fuse_kernel_bsd.go
@@ -1,3 +1,5 @@
+// +build openbsd freebsd
+
 package fuse
 
 import "time"

--- a/mount_bsd.go
+++ b/mount_bsd.go
@@ -1,3 +1,5 @@
+// +build openbsd freebsd
+
 package fuse
 
 import (

--- a/options_bsd.go
+++ b/options_bsd.go
@@ -1,3 +1,5 @@
+// +build openbsd freebsd
+
 package fuse
 
 func localVolume(conf *mountConfig) error {


### PR DESCRIPTION
This commit contains the following changes:
 * Rename *_freebsd.go -> *_bsd.go
 * Add build tag to *_bsd.go to build for FreeBSD and OpenBSD
 * Replace syscall.EPROTO with syscall.EIO, as the latter is the more portable error code. This change was inspired by sshfs, which introduced it in 2005 (release 1.4).