### PR TITLE
Stop over-allocating receive buffers for large writes.

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -212,7 +212,7 @@ func initMount(c *Conn, conf *mountConfig) error {
 	s := &InitResponse{
 		Library:      proto,
 		MaxReadahead: conf.maxReadahead,
-		MaxWrite:     128 * 1024,
+		MaxWrite:     maxWrite,
 		Flags:        InitBigWrites | conf.initFlags,
 	}
 	r.Respond(s)
@@ -367,9 +367,6 @@ func (h *Header) RespondError(err error) {
 	hOut.Error = -int32(errno)
 	h.respond(buf)
 }
-
-// Maximum file write size we are prepared to receive from the kernel.
-const maxWrite = 16 * 1024 * 1024
 
 // All requests read from the kernel, without data, are shorter than
 // this.

--- a/mount_darwin.go
+++ b/mount_darwin.go
@@ -11,6 +11,11 @@ import (
 	"syscall"
 )
 
+// OS X appears to cap the size of writes to 1 MiB. This constant is also used
+// for sizing receive buffers, so make it as small as it can be without
+// limiting write sizes.
+const maxWrite = 1 << 20
+
 var errNoAvail = errors.New("no available fuse devices")
 
 var errNotLoaded = errors.New("osxfusefs is not loaded")

--- a/mount_freebsd.go
+++ b/mount_freebsd.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// Maximum file write size we are prepared to receive from the kernel.
+const maxWrite = 128 * 1024
+
 func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (*os.File, error) {
 	for k, v := range conf.options {
 		if strings.Contains(k, ",") || strings.Contains(v, ",") {

--- a/mount_linux.go
+++ b/mount_linux.go
@@ -12,6 +12,10 @@ import (
 	"syscall"
 )
 
+// Maximum file write size we are prepared to receive from the kernel. Linux
+// appears to limit writes to 128 KiB.
+const maxWrite = 128 * 1024
+
 func lineLogger(wg *sync.WaitGroup, prefix string, r io.ReadCloser) {
 	defer wg.Done()
 


### PR DESCRIPTION
The maxWrite constant used to size buffers was 16 MiB, even though InitRequest.Respond always tells the kernel we want writes of 128 KiB. Caveat: mount_darwin.go implies that on darwin we were still telling the kernel 16 MiB, but experimentally it was capping this to 1 MiB.

Now use exactly those sizes on those operating systems. On FreeBSD continue to use 128 KiB, because I'm not sure what it does.

Allocating and zeroing buffers in allocMessage is a large source of CPU usage in a read-heavy load; I believe this change will help there.

For what it's worth, this improved the sequential read throughput of GoogleCloudPlatform/gcsfuse by about 36%.