### PR TITLE
Replaced sync.Pool with a dead-simple freelist.

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -384,18 +384,31 @@ var bufSize = maxRequestSize + maxWrite
 //
 // Messages in the pool are guaranteed to have conn and off zeroed,
 // buf allocated and len==bufSize, and hdr set.
-var reqPool = sync.Pool{
-	New: allocMessage,
+var reqPool struct {
+	Mu       sync.Mutex
+	Freelist []*message
 }
 
-func allocMessage() interface{} {
+func allocMessage() *message {
 	m := &message{buf: make([]byte, bufSize)}
 	m.hdr = (*inHeader)(unsafe.Pointer(&m.buf[0]))
 	return m
 }
 
-func getMessage(c *Conn) *message {
-	m := reqPool.Get().(*message)
+func getMessage(c *Conn) (m *message) {
+	reqPool.Mu.Lock()
+	l := len(reqPool.Freelist)
+	if l != 0 {
+		m = reqPool.Freelist[l-1]
+		reqPool.Freelist = reqPool.Freelist[:l-1]
+	}
+
+	reqPool.Mu.Unlock()
+
+	if m == nil {
+		m = allocMessage()
+	}
+
 	m.conn = c
 	return m
 }
@@ -404,7 +417,10 @@ func putMessage(m *message) {
 	m.buf = m.buf[:bufSize]
 	m.conn = nil
 	m.off = 0
-	reqPool.Put(m)
+
+	reqPool.Mu.Lock()
+	reqPool.Freelist = append(reqPool.Freelist, m)
+	reqPool.Mu.Unlock()
 }
 
 // a message represents the bytes of a single FUSE message


### PR DESCRIPTION
The behavior of sync.Pool is hard to predict, because it interacts with
garbage collection. It goes to considerable effort to not retain items
in its freelist when there is memory pressure, but this can cause
pathological behavior where we allocate over and over again when in
theory we need only one message in flight
(cf. http://golang.org/issue/11834).

This change causes allocMessage to go from allocating hundreds of MB per
second in my read throughput benchmark to not being in the profile at
all.

The downside is that the freelist grows to a high water mark of messages
that were needed concurrently, and then stays there. I suspect this is
not a problem in practice. If it is, then we could either reset it
periodically, or use additive increase/multiplicative decrease
(cf. https://goo.gl/uk7JS9) on its capacity.