### PR TITLE
Stop over-allocating receive buffers for large writes

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -235,7 +235,7 @@ func initMount(c *Conn, conf *mountConfig) error {
 	s := &InitResponse{
 		Library:      proto,
 		MaxReadahead: conf.maxReadahead,
-		MaxWrite:     128 * 1024,
+		MaxWrite:     maxWrite,
 		Flags:        InitBigWrites | conf.initFlags,
 	}
 	r.Respond(s)
@@ -402,9 +402,6 @@ func (h *Header) RespondError(err error) {
 	hOut.Error = -int32(errno)
 	h.respond(buf)
 }
-
-// Maximum file write size we are prepared to receive from the kernel.
-const maxWrite = 16 * 1024 * 1024
 
 // All requests read from the kernel, without data, are shorter than
 // this.

--- a/mount_darwin.go
+++ b/mount_darwin.go
@@ -13,6 +13,11 @@ import (
 	"syscall"
 )
 
+// OS X appears to cap the size of writes to 1 MiB. This constant is also used
+// for sizing receive buffers, so make it as small as it can be without
+// limiting write sizes.
+const maxWrite = 1 << 20
+
 var (
 	errNoAvail         = errors.New("no available fuse devices")
 	errNotLoaded       = errors.New("osxfuse is not loaded")

--- a/mount_freebsd.go
+++ b/mount_freebsd.go
@@ -10,6 +10,9 @@ import (
 	"syscall"
 )
 
+// Maximum file write size we are prepared to receive from the kernel.
+const maxWrite = 128 * 1024
+
 func handleMountFusefsStderr(errCh chan<- error) func(line string) (ignore bool) {
 	return func(line string) (ignore bool) {
 		const (

--- a/mount_linux.go
+++ b/mount_linux.go
@@ -11,6 +11,10 @@ import (
 	"syscall"
 )
 
+// Maximum file write size we are prepared to receive from the kernel. Linux
+// appears to limit writes to 128 KiB.
+const maxWrite = 128 * 1024
+
 func handleFusermountStderr(errCh chan<- error) func(line string) (ignore bool) {
 	return func(line string) (ignore bool) {
 		if line == `fusermount: failed to open /etc/fuse.conf: Permission denied` {


### PR DESCRIPTION
This is a straight rebase of #106 by @jacobsa.