### PR TITLE
add single readdir callback

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -1912,12 +1912,17 @@ func (t DirentType) String() string {
 // AppendDirent appends the encoded form of a directory entry to data
 // and returns the resulting slice.
 func AppendDirent(data []byte, dir Dirent) []byte {
+	off := uint64(len(data) + direntSize + (len(dir.Name)+7)&^7)
+	return AppendDirentAt(data, dir, off)
+}
+
+func AppendDirentAt(data []byte, dir Dirent, off uint64) []byte {
 	de := dirent{
 		Ino:     dir.Inode,
 		Namelen: uint32(len(dir.Name)),
 		Type:    uint32(dir.Type),
 	}
-	de.Off = uint64(len(data) + direntSize + (len(dir.Name)+7)&^7)
+	de.Off = off + 1
 	data = append(data, (*[direntSize]byte)(unsafe.Pointer(&de))[:]...)
 	data = append(data, dir.Name...)
 	n := direntSize + uintptr(len(dir.Name))


### PR DESCRIPTION
most underly storage systems only support partial readdir, either
through posix-like single readdir or s3 like page readdir. the
existing ReadDirAller interface requires implementations to wait
for multiple round-trips before returning any result which hurts
performance
