### PR TITLE
Replace NodeFsyncer with HandleFsyncer

### DIFF
--- a/fs/bench/bench_test.go
+++ b/fs/bench/bench_test.go
@@ -62,8 +62,8 @@ type benchFile struct {
 
 var _ = fs.Node(benchFile{})
 var _ = fs.NodeOpener(benchFile{})
-var _ = fs.NodeFsyncer(benchFile{})
 var _ = fs.Handle(benchFile{})
+var _ = fs.HandleFsyncer(benchFile{})
 var _ = fs.HandleReader(benchFile{})
 var _ = fs.HandleWriter(benchFile{})
 

--- a/fs/fstestutil/record/record.go
+++ b/fs/fstestutil/record/record.go
@@ -139,7 +139,7 @@ type Fsyncs struct {
 	rec RequestRecorder
 }
 
-var _ = fs.NodeFsyncer(&Fsyncs{})
+var _ = fs.HandleFsyncer(&Fsyncs{})
 
 func (r *Fsyncs) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
 	tmp := *req


### PR DESCRIPTION
Fsync should happen on a handle to an open file, so that filesystems
can more easily find the backing file descriptor to call fsync on.

This fixes a TODO in the code.