### PR TITLE
fuse: add DaemonTimeout mount option to set request timeout.

### DIFF
--- a/options.go
+++ b/options.go
@@ -83,6 +83,14 @@ func VolumeName(name string) MountOption {
 	return volumeName(name)
 }
 
+// DaemonTimeout sets the time in seconds between a request and a reply before
+// the FUSE mount is declared dead.
+//
+// OS X and FreeBSD only. Others ignore this option.
+func DaemonTimeout(name string) MountOption {
+	return daemonTimeout(name)
+}
+
 var ErrCannotCombineAllowOtherAndAllowRoot = errors.New("cannot combine AllowOther and AllowRoot")
 
 // AllowOther allows other users to access the file system.

--- a/options_daemon_timeout_test.go
+++ b/options_daemon_timeout_test.go
@@ -1,0 +1,56 @@
+// Test for adjustable timeout between a FUSE request and the daemon's response.
+//
+// +build darwin freebsd
+
+package fuse_test
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"bazil.org/fuse/fs/fstestutil"
+	"golang.org/x/net/context"
+)
+
+type slowCreaterDir struct {
+	fstestutil.Dir
+}
+
+var _ fs.NodeCreater = slowCreaterDir{}
+
+func (c slowCreaterDir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
+	time.Sleep(10*time.Second)
+	// pick a really distinct error, to identify it later
+	return nil, nil, fuse.Errno(syscall.ENAMETOOLONG)
+}
+
+func TestDaemonTimeout(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "freebsd" {
+		return
+	}
+	t.Parallel()
+	mnt, err := fstestutil.MountedT(t,
+		fstestutil.SimpleFS{slowCreaterDir{}},
+		nil,
+		fuse.DaemonTimeout("2"),
+	)
+
+	// This should fail by the kernel timing out the request.
+	f, err := os.Create(mnt.Dir + "/child")
+	if err == nil {
+		f.Close()
+		t.Fatal("expected an error")
+	}
+	perr, ok := err.(*os.PathError)
+	if !ok {
+		t.Fatalf("expected PathError, got %T: %v", err, err)
+	}
+	if perr.Err == syscall.ENAMETOOLONG {
+		t.Fatalf("expected other than ENAMETOOLONG, got %T: %v", err, err)
+	}
+}

--- a/options_darwin.go
+++ b/options_darwin.go
@@ -11,3 +11,10 @@ func volumeName(name string) MountOption {
 		return nil
 	}
 }
+
+func daemonTimeout(name string) MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["daemon_timeout"] = name
+		return nil
+	}
+}

--- a/options_freebsd.go
+++ b/options_freebsd.go
@@ -7,3 +7,10 @@ func localVolume(conf *mountConfig) error {
 func volumeName(name string) MountOption {
 	return dummyOption
 }
+
+func daemonTimeout(name string) MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["timeout"] = name
+		return nil
+	}
+}

--- a/options_linux.go
+++ b/options_linux.go
@@ -7,3 +7,7 @@ func localVolume(conf *mountConfig) error {
 func volumeName(name string) MountOption {
 	return dummyOption
 }
+
+func daemonTimeout(name string) MountOption {
+	return dummyOption
+}

--- a/options_test.go
+++ b/options_test.go
@@ -196,7 +196,7 @@ type createrDir struct {
 
 var _ fs.NodeCreater = createrDir{}
 
-func (createrDir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
+func (c createrDir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
 	// pick a really distinct error, to identify it later
 	return nil, nil, fuse.Errno(syscall.ENAMETOOLONG)
 }


### PR DESCRIPTION
Should work on both freebsd and darwin but I haven't tested it on freebsd.