### PR TITLE
Master

### DIFF
--- a/examples/clockfs/clockfs.go
+++ b/examples/clockfs/clockfs.go
@@ -11,10 +11,10 @@ import (
 	"syscall"
 	"time"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
-	_ "bazil.org/fuse/fs/fstestutil"
-	"bazil.org/fuse/fuseutil"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
+	_ "github.com/presotto/fuse/fs/fstestutil"
+	"github.com/presotto/fuse/fuseutil"
 	"golang.org/x/net/context"
 )
 

--- a/examples/hellofs/hello.go
+++ b/examples/hellofs/hello.go
@@ -7,9 +7,9 @@ import (
 	"log"
 	"os"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
-	_ "bazil.org/fuse/fs/fstestutil"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
+	_ "github.com/presotto/fuse/fs/fstestutil"
 	"golang.org/x/net/context"
 )
 

--- a/fs/bench/bench_test.go
+++ b/fs/bench/bench_test.go
@@ -7,9 +7,9 @@ import (
 	"path"
 	"testing"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
-	"bazil.org/fuse/fs/fstestutil"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
+	"github.com/presotto/fuse/fs/fstestutil"
 	"golang.org/x/net/context"
 )
 

--- a/fs/fstestutil/debug.go
+++ b/fs/fstestutil/debug.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"bazil.org/fuse"
+	"github.com/presotto/fuse"
 )
 
 type flagDebug bool

--- a/fs/fstestutil/doc.go
+++ b/fs/fstestutil/doc.go
@@ -1,1 +1,1 @@
-package fstestutil // import "bazil.org/fuse/fs/fstestutil"
+package fstestutil // import "github.com/presotto/fuse/fs/fstestutil"

--- a/fs/fstestutil/mounted.go
+++ b/fs/fstestutil/mounted.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
 )
 
 // Mount contains information about the mount for the test to use.

--- a/fs/fstestutil/record/record.go
+++ b/fs/fstestutil/record/record.go
@@ -1,11 +1,11 @@
-package record // import "bazil.org/fuse/fs/fstestutil/record"
+package record // import "github.com/presotto/fuse/fs/fstestutil/record"
 
 import (
 	"sync"
 	"sync/atomic"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
 	"golang.org/x/net/context"
 )
 

--- a/fs/fstestutil/record/wait.go
+++ b/fs/fstestutil/record/wait.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
 	"golang.org/x/net/context"
 )
 

--- a/fs/fstestutil/testfs.go
+++ b/fs/fstestutil/testfs.go
@@ -3,8 +3,8 @@ package fstestutil
 import (
 	"os"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
 	"golang.org/x/net/context"
 )
 

--- a/fs/serve.go
+++ b/fs/serve.go
@@ -1,6 +1,6 @@
 // FUSE service loop, for servers that wish to use it.
 
-package fs // import "bazil.org/fuse/fs"
+package fs // import "github.com/presotto/fuse/fs"
 
 import (
 	"encoding/binary"
@@ -20,8 +20,8 @@ import (
 import (
 	"bytes"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fuseutil"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fuseutil"
 )
 
 const (

--- a/fs/serve_darwin_test.go
+++ b/fs/serve_darwin_test.go
@@ -3,7 +3,7 @@ package fs_test
 import (
 	"testing"
 
-	"bazil.org/fuse/fs/fstestutil"
+	"github.com/presotto/fuse/fs/fstestutil"
 	"golang.org/x/sys/unix"
 )
 

--- a/fs/serve_test.go
+++ b/fs/serve_test.go
@@ -16,12 +16,12 @@ import (
 	"testing"
 	"time"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
-	"bazil.org/fuse/fs/fstestutil"
-	"bazil.org/fuse/fs/fstestutil/record"
-	"bazil.org/fuse/fuseutil"
-	"bazil.org/fuse/syscallx"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
+	"github.com/presotto/fuse/fs/fstestutil"
+	"github.com/presotto/fuse/fs/fstestutil/record"
+	"github.com/presotto/fuse/fuseutil"
+	"github.com/presotto/fuse/syscallx"
 	"golang.org/x/net/context"
 )
 

--- a/fs/tree.go
+++ b/fs/tree.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"bazil.org/fuse"
+	"github.com/presotto/fuse"
 )
 
 // A Tree implements a basic read-only directory tree for FUSE.

--- a/fuse.go
+++ b/fuse.go
@@ -98,7 +98,7 @@
 // Behavior and metadata of the mounted file system can be changed by
 // passing MountOption values to Mount.
 //
-package fuse // import "bazil.org/fuse"
+package fuse // import "github.com/presotto/fuse"
 
 import (
 	"bytes"

--- a/fuse_kernel_test.go
+++ b/fuse_kernel_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"bazil.org/fuse"
+	"github.com/presotto/fuse"
 )
 
 func TestOpenFlagsAccmodeMaskReadWrite(t *testing.T) {

--- a/fuseutil/fuseutil.go
+++ b/fuseutil/fuseutil.go
@@ -1,7 +1,7 @@
-package fuseutil // import "bazil.org/fuse/fuseutil"
+package fuseutil // import "github.com/presotto/fuse/fuseutil"
 
 import (
-	"bazil.org/fuse"
+	"github.com/presotto/fuse"
 )
 
 // HandleRead handles a read request assuming that data is the entire file content.

--- a/mount_darwin.go
+++ b/mount_darwin.go
@@ -114,6 +114,7 @@ func callMount(bin string, daemonVar string, dir string, conf *mountConfig, f *o
 	cmd.ExtraFiles = []*os.File{f}
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "MOUNT_FUSEFS_CALL_BY_LIB=")
+	cmd.Env = append(cmd.Env, "MOUNT_OSXFUSE_CALL_BY_LIB=")
 
 	daemon := os.Args[0]
 	if daemonVar != "" {

--- a/options.go
+++ b/options.go
@@ -83,6 +83,14 @@ func VolumeName(name string) MountOption {
 	return volumeName(name)
 }
 
+// DaemonTimeout sets the time in seconds between a request and a reply before
+// the FUSE mount is declared dead.
+//
+// OS X and FreeBSD only. Others ignore this option.
+func DaemonTimeout(name string) MountOption {
+	return daemonTimeout(name)
+}
+
 var ErrCannotCombineAllowOtherAndAllowRoot = errors.New("cannot combine AllowOther and AllowRoot")
 
 // AllowOther allows other users to access the file system.

--- a/options.go
+++ b/options.go
@@ -59,13 +59,9 @@ func FSName(name string) MountOption {
 // `fuse`. The type in a list of mounted file systems will look like
 // `fuse.foo`.
 //
-// OS X ignores this option.
 // FreeBSD ignores this option.
 func Subtype(fstype string) MountOption {
-	return func(conf *mountConfig) error {
-		conf.options["fssubtype"] = fstype
-		return nil
-	}
+	return subtype(fstype)
 }
 
 // LocalVolume sets the volume to be local (instead of network),

--- a/options.go
+++ b/options.go
@@ -63,7 +63,7 @@ func FSName(name string) MountOption {
 // FreeBSD ignores this option.
 func Subtype(fstype string) MountOption {
 	return func(conf *mountConfig) error {
-		conf.options["subtype"] = fstype
+		conf.options["fssubtype"] = fstype
 		return nil
 	}
 }
@@ -81,6 +81,22 @@ func LocalVolume() MountOption {
 // OS X only. Others ignore this option.
 func VolumeName(name string) MountOption {
 	return volumeName(name)
+}
+
+// NoAppleDouble prefents the kernel extension from storing or retrieving extended
+// attributes in ._<filename> files.
+//
+// OS X only.  Others ignore this option.
+func NoAppleDouble() MountOption {
+	return noAppleDouble
+}
+
+
+// NoAppleXattr causes the kernel extension from using com.apple extended attibutes.
+//
+// OS X only.  Others ignore this option.
+func NoAppleXattr() MountOption {
+	return noAppleXattr
 }
 
 // DaemonTimeout sets the time in seconds between a request and a reply before

--- a/options_daemon_timeout_test.go
+++ b/options_daemon_timeout_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
-	"bazil.org/fuse/fs/fstestutil"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
+	"github.com/presotto/fuse/fs/fstestutil"
 	"golang.org/x/net/context"
 )
 

--- a/options_daemon_timeout_test.go
+++ b/options_daemon_timeout_test.go
@@ -1,0 +1,56 @@
+// Test for adjustable timeout between a FUSE request and the daemon's response.
+//
+// +build darwin freebsd
+
+package fuse_test
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"bazil.org/fuse/fs/fstestutil"
+	"golang.org/x/net/context"
+)
+
+type slowCreaterDir struct {
+	fstestutil.Dir
+}
+
+var _ fs.NodeCreater = slowCreaterDir{}
+
+func (c slowCreaterDir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
+	time.Sleep(10*time.Second)
+	// pick a really distinct error, to identify it later
+	return nil, nil, fuse.Errno(syscall.ENAMETOOLONG)
+}
+
+func TestDaemonTimeout(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "freebsd" {
+		return
+	}
+	t.Parallel()
+	mnt, err := fstestutil.MountedT(t,
+		fstestutil.SimpleFS{slowCreaterDir{}},
+		nil,
+		fuse.DaemonTimeout("2"),
+	)
+
+	// This should fail by the kernel timing out the request.
+	f, err := os.Create(mnt.Dir + "/child")
+	if err == nil {
+		f.Close()
+		t.Fatal("expected an error")
+	}
+	perr, ok := err.(*os.PathError)
+	if !ok {
+		t.Fatalf("expected PathError, got %T: %v", err, err)
+	}
+	if perr.Err == syscall.ENAMETOOLONG {
+		t.Fatalf("expected other than ENAMETOOLONG, got %T: %v", err, err)
+	}
+}

--- a/options_darwin.go
+++ b/options_darwin.go
@@ -18,3 +18,13 @@ func daemonTimeout(name string) MountOption {
 		return nil
 	}
 }
+
+func noAppleXattr(conf *mountConfig) error {
+	conf.options["noapplexattr"] = ""
+	return nil
+}
+
+func noAppleDouble(conf *mountConfig) error {
+	conf.options["noappledouble"] = ""
+	return nil
+}

--- a/options_darwin.go
+++ b/options_darwin.go
@@ -11,3 +11,10 @@ func volumeName(name string) MountOption {
 		return nil
 	}
 }
+
+func daemonTimeout(name string) MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["daemon_timeout"] = name
+		return nil
+	}
+}

--- a/options_darwin.go
+++ b/options_darwin.go
@@ -28,3 +28,10 @@ func noAppleDouble(conf *mountConfig) error {
 	conf.options["noappledouble"] = ""
 	return nil
 }
+
+func subtype(fstype string) MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["fssubtype"] = fstype
+		return nil
+	}
+}

--- a/options_freebsd.go
+++ b/options_freebsd.go
@@ -15,10 +15,10 @@ func daemonTimeout(name string) MountOption {
 	}
 }
 
-func noAppleXattr(conf *mountConfig) MountOption {
+func noAppleXattr(conf *mountConfig) error {
 	return nil
 }
 
-func noAppleDouble(conf *mountConfig) MountOption {
+func noAppleDouble(conf *mountConfig) error {
 	return nil
 }

--- a/options_freebsd.go
+++ b/options_freebsd.go
@@ -7,3 +7,10 @@ func localVolume(conf *mountConfig) error {
 func volumeName(name string) MountOption {
 	return dummyOption
 }
+
+func daemonTimeout(name string) MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["timeout"] = name
+		return nil
+	}
+}

--- a/options_freebsd.go
+++ b/options_freebsd.go
@@ -22,3 +22,9 @@ func noAppleXattr(conf *mountConfig) error {
 func noAppleDouble(conf *mountConfig) error {
 	return nil
 }
+
+func subtype(fstype string) MountOption {
+	return func(conf *mountConfig) error {
+		return nil
+	}
+}

--- a/options_freebsd.go
+++ b/options_freebsd.go
@@ -14,3 +14,11 @@ func daemonTimeout(name string) MountOption {
 		return nil
 	}
 }
+
+func noAppleXattr(conf *mountConfig) MountOption {
+	return nil
+}
+
+func noAppleDouble(conf *mountConfig) MountOption {
+	return nil
+}

--- a/options_linux.go
+++ b/options_linux.go
@@ -7,3 +7,7 @@ func localVolume(conf *mountConfig) error {
 func volumeName(name string) MountOption {
 	return dummyOption
 }
+
+func daemonTimeout(name string) MountOption {
+	return dummyOption
+}

--- a/options_linux.go
+++ b/options_linux.go
@@ -12,10 +12,10 @@ func daemonTimeout(name string) MountOption {
 	return dummyOption
 }
 
-func noAppleXattr(conf *mountConfig) MountOption {
+func noAppleXattr(conf *mountConfig) error {
 	return nil
 }
 
-func noAppleDouble(conf *mountConfig) MountOption {
+func noAppleDouble(conf *mountConfig) error {
 	return nil
 }

--- a/options_linux.go
+++ b/options_linux.go
@@ -11,3 +11,11 @@ func volumeName(name string) MountOption {
 func daemonTimeout(name string) MountOption {
 	return dummyOption
 }
+
+func noAppleXattr(conf *mountConfig) MountOption {
+	return nil
+}
+
+func noAppleDouble(conf *mountConfig) MountOption {
+	return nil
+}

--- a/options_linux.go
+++ b/options_linux.go
@@ -19,3 +19,10 @@ func noAppleXattr(conf *mountConfig) error {
 func noAppleDouble(conf *mountConfig) error {
 	return nil
 }
+
+func subtype(fstype string) MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["subtype"] = fstype
+		return nil
+	}
+}

--- a/options_nocomma_test.go
+++ b/options_nocomma_test.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 	"testing"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs/fstestutil"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs/fstestutil"
 )
 
 func TestMountOptionCommaError(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -196,7 +196,7 @@ type createrDir struct {
 
 var _ fs.NodeCreater = createrDir{}
 
-func (createrDir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
+func (c createrDir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (fs.Node, fs.Handle, error) {
 	// pick a really distinct error, to identify it later
 	return nil, nil, fuse.Errno(syscall.ENAMETOOLONG)
 }

--- a/options_test.go
+++ b/options_test.go
@@ -6,9 +6,9 @@ import (
 	"syscall"
 	"testing"
 
-	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
-	"bazil.org/fuse/fs/fstestutil"
+	"github.com/presotto/fuse"
+	"github.com/presotto/fuse/fs"
+	"github.com/presotto/fuse/fs/fstestutil"
 	"golang.org/x/net/context"
 )
 

--- a/syscallx/doc.go
+++ b/syscallx/doc.go
@@ -10,4 +10,4 @@
 //
 // Options can be implemented with separate wrappers, in the style of
 // Linux getxattr/lgetxattr/fgetxattr.
-package syscallx // import "bazil.org/fuse/syscallx"
+package syscallx // import "github.com/presotto/fuse/syscallx"


### PR DESCRIPTION
1) Added support for more osxfuse options
2) fixed subtype option, had wrong name
3) added an env variable required by the helper used for osxfuse 3.3.2.  They changed the variable used to indicate a library calling the helper for some unknown reason.