### PR TITLE
add support for excl_create mount option

### DIFF
--- a/options.go
+++ b/options.go
@@ -106,6 +106,14 @@ func NoAppleXattr() MountOption {
 	return noAppleXattr
 }
 
+// ExclCreate causes O_EXCL flag to be set for only "truly" exclusive creates,
+// i.e. create calls for which the initiator explicitly set the O_EXCL flag.
+//
+// OS X only. Others ignore this options.
+func ExclCreate() MountOption {
+	return exclCreate
+}
+
 // DaemonTimeout sets the time in seconds between a request and a reply before
 // the FUSE mount is declared dead.
 //

--- a/options_darwin.go
+++ b/options_darwin.go
@@ -28,3 +28,8 @@ func noAppleDouble(conf *mountConfig) error {
 	conf.options["noappledouble"] = ""
 	return nil
 }
+
+func exclCreate(conf *mountConfig) error {
+	conf.options["excl_create"] = ""
+	return nil
+}

--- a/options_freebsd.go
+++ b/options_freebsd.go
@@ -22,3 +22,7 @@ func noAppleXattr(conf *mountConfig) error {
 func noAppleDouble(conf *mountConfig) error {
 	return nil
 }
+
+func exclCreate(conf *mountConfig) error {
+	return nil
+}

--- a/options_linux.go
+++ b/options_linux.go
@@ -19,3 +19,7 @@ func noAppleXattr(conf *mountConfig) error {
 func noAppleDouble(conf *mountConfig) error {
 	return nil
 }
+
+func exclCreate(conf *mountConfig) error {
+	return nil
+}


### PR DESCRIPTION
Hey there! This PR adds support for `excl_create` mount option. It was added in OSXFuse 3.4.1: https://github.com/osxfuse/osxfuse/releases/tag/osxfuse-3.4.1