### PR TITLE
options: Introduce a new option: AllowNonEmptyMount

### DIFF
--- a/options.go
+++ b/options.go
@@ -270,3 +270,15 @@ func OSXFUSELocations(paths ...OSXFUSEPaths) MountOption {
 		return nil
 	}
 }
+
+// AllowNonEmptyMount allows the mounting over a non-empty directory.
+//
+// The files in it will be shadowed by the freshly created mount.
+// By default these  mounts are rejected to prevent accidental covering up of
+// data, which could for example prevent automatic backup.
+func AllowNonEmptyMount() MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["nonempty"] = ""
+		return nil
+	}
+}


### PR DESCRIPTION
This option allows the mounting over a non-empty directory and shadows the files
in it, if any. I didn't see this MountOption yet in the package.
It simply passes 'nonempty' to '-o'.