### PR TITLE
Add AsyncDIO as mount option

### DIFF
--- a/options.go
+++ b/options.go
@@ -235,6 +235,16 @@ func AsyncRead() MountOption {
 	}
 }
 
+// AsyncDIO enables multiple outstanding read/write requests for the same
+// handle. It required the file to be opened with O_DIRECT, and
+// fuse.OpenDirectIO flag must not be set for this to take effect
+func AsyncDIO() MountOption {
+	return func(conf *mountConfig) error {
+		conf.initFlags |= InitAsyncDIO
+		return nil
+	}
+}
+
 // WritebackCache enables the kernel to buffer writes before sending
 // them to the FUSE server. Without this, writethrough caching is
 // used.


### PR DESCRIPTION
AsyncDIO enables multiple outstanding read/write requests for the same handle.
It required the file to be opened with O_DIRECT, and fuse.OpenDirectIO flag must
not be set for this to take effect.