### PR TITLE
Add "noexec" mount option

### DIFF
--- a/options.go
+++ b/options.go
@@ -188,7 +188,7 @@ func AllowSUID() MountOption {
 	}
 }
 
-// NoExec disable de execution of binaries in the file system
+// NoExec disable the execution of binaries on the file system
 
 func NoExec() MountOption {
 	return func(conf *mountConfig) error {

--- a/options.go
+++ b/options.go
@@ -188,6 +188,15 @@ func AllowSUID() MountOption {
 	}
 }
 
+// NoExec disable de execution of binaries in the file system
+
+func NoExec() MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["noexec"] = ""
+		return nil
+	}
+}
+
 // DefaultPermissions makes the kernel enforce access control based on
 // the file mode (as in chmod).
 //


### PR DESCRIPTION
The "noexec" mount option deny direct execution of any binaries on the mounted filesystem.