### PR TITLE
dd handle HandleStreamingReader

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -1764,6 +1764,12 @@ func (r *ReadRequest) Respond(resp *ReadResponse) {
 	r.respond(buf)
 }
 
+func (r *ReadRequest) StreamingRespond(resp *StreamingReadResponse) {
+	buf := resp.Data()
+	r.respond(buf)
+	returnBuffer(buf)
+}
+
 // A ReadResponse is the response to a ReadRequest.
 type ReadResponse struct {
 	Data []byte
@@ -1771,6 +1777,28 @@ type ReadResponse struct {
 
 func (r *ReadResponse) String() string {
 	return fmt.Sprintf("Read %d", len(r.Data))
+}
+
+func NewStreamingReadResponse() *StreamingReadResponse {
+	return &StreamingReadResponse{buf: newStreamingBuffer()}
+}
+
+// A StreamingReadResponse is the response to a ReadRequests wich
+// supports streaming the response via a io.Writer
+type StreamingReadResponse struct {
+	buf *bytes.Buffer
+}
+
+func (resp *StreamingReadResponse) Write(p []byte) (int, error) {
+	return resp.buf.Write(p)
+}
+
+func (resp *StreamingReadResponse) Data() []byte {
+	return resp.buf.Bytes()
+}
+
+func (r *StreamingReadResponse) String() string {
+	return fmt.Sprintf("Read %d", len(r.Data()))
 }
 
 type jsonReadResponse struct {


### PR DESCRIPTION
This commit introduces a new type 'StreamingReadResponse' which
implements the io.Writer interface. Thus users are writing into the
response rather than updating the Data property of ReadResponse. This
allows us to preallocate the space for the whole message and therefore
reduce allocations. Additionally we may now use a sync.Pool to manage
the required space needed for the read request and further minimize
allocations.

This patch intends to not break existing implementations of the
fuse.HandleReader interface by introducing a new interface that provides
the advantages described above.

I've benchmarked this using a scenario that is similar to the
environment I need for the application I am currently developing. The
benchmark reads data blobs of different sizes from the solid-state
drive. Using this patch we can achieve a 1.60x speed up as well as
reduce memory allocations by 85%.

[benchmark.txt](https://github.com/bazil/fuse/files/570909/bazil_patch_bench.txt)