### PR TITLE
Performance improvements

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -20,14 +20,6 @@ func (w *buffer) alloc(size uintptr) unsafe.Pointer {
 	return unsafe.Pointer(&(*w)[l])
 }
 
-// reset clears out the contents of the buffer.
-func (w *buffer) reset() {
-	for i := range (*w)[:cap(*w)] {
-		(*w)[i] = 0
-	}
-	*w = (*w)[:0]
-}
-
 func newBuffer(extra uintptr) buffer {
 	const hdrSize = unsafe.Sizeof(outHeader{})
 	buf := make(buffer, hdrSize, hdrSize+extra)

--- a/debug.go
+++ b/debug.go
@@ -9,8 +9,6 @@ func stack() string {
 	return string(buf[:runtime.Stack(buf, false)])
 }
 
-func nop(msg interface{}) {}
-
 // Debug is called to output debug messages, including protocol
 // traces. The default behavior is to do nothing.
 //
@@ -18,4 +16,4 @@ func nop(msg interface{}) {}
 // safe to marshal to JSON.
 //
 // Implementations must not retain msg.
-var Debug func(msg interface{}) = nop
+var Debug func(msg interface{})

--- a/examples/clockfs/clockfs.go
+++ b/examples/clockfs/clockfs.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -15,7 +16,6 @@ import (
 	"bazil.org/fuse/fs"
 	_ "bazil.org/fuse/fs/fstestutil"
 	"bazil.org/fuse/fuseutil"
-	"golang.org/x/net/context"
 )
 
 func usage() {

--- a/examples/hellofs/hello.go
+++ b/examples/hellofs/hello.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -10,7 +11,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	_ "bazil.org/fuse/fs/fstestutil"
-	"golang.org/x/net/context"
 )
 
 func usage() {

--- a/fs/bench/bench_create_test.go
+++ b/fs/bench/bench_create_test.go
@@ -1,6 +1,7 @@
 package bench_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -8,7 +9,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
-	"golang.org/x/net/context"
 )
 
 type dummyFile struct {

--- a/fs/bench/bench_lookup_test.go
+++ b/fs/bench/bench_lookup_test.go
@@ -1,10 +1,9 @@
 package bench_test
 
 import (
+	"context"
 	"os"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"

--- a/fs/bench/bench_readwrite_test.go
+++ b/fs/bench/bench_readwrite_test.go
@@ -1,6 +1,7 @@
 package bench_test
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
-	"golang.org/x/net/context"
 )
 
 type benchConfig struct {

--- a/fs/fstestutil/record/record.go
+++ b/fs/fstestutil/record/record.go
@@ -1,12 +1,12 @@
 package record // import "bazil.org/fuse/fs/fstestutil/record"
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"golang.org/x/net/context"
 )
 
 // Writes gathers data from FUSE Write calls.

--- a/fs/fstestutil/record/wait.go
+++ b/fs/fstestutil/record/wait.go
@@ -1,12 +1,12 @@
 package record
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"golang.org/x/net/context"
 )
 
 type nothing struct{}

--- a/fs/fstestutil/testfs.go
+++ b/fs/fstestutil/testfs.go
@@ -1,11 +1,11 @@
 package fstestutil
 
 import (
+	"context"
 	"os"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"golang.org/x/net/context"
 )
 
 // SimpleFS is a trivial FS that just implements the Root method.

--- a/fs/serve.go
+++ b/fs/serve.go
@@ -3,6 +3,7 @@
 package fs // import "bazil.org/fuse/fs"
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"hash/fnv"
@@ -13,8 +14,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 import (

--- a/fs/serve.go
+++ b/fs/serve.go
@@ -532,7 +532,9 @@ func (c *Server) dropNode(id fuse.NodeID, n uint64) (forget bool) {
 		// this should only happen if refcounts kernel<->us disagree
 		// *and* two ForgetRequests for the same node race each other;
 		// this indicates a bug somewhere
-		c.debug(nodeRefcountDropBug{N: n, Node: id})
+		if c.debug != nil {
+			c.debug(nodeRefcountDropBug{N: n, Node: id})
+		}
 
 		// we may end up triggering Forget twice, but that's better
 		// than not even once, and that's the best we can do
@@ -540,7 +542,9 @@ func (c *Server) dropNode(id fuse.NodeID, n uint64) (forget bool) {
 	}
 
 	if n > snode.refs {
-		c.debug(nodeRefcountDropBug{N: n, Refs: snode.refs, Node: id})
+		if c.debug != nil {
+			c.debug(nodeRefcountDropBug{N: n, Refs: snode.refs, Node: id})
+		}
 		n = snode.refs
 	}
 
@@ -579,10 +583,12 @@ func (c *Server) getHandle(id fuse.HandleID) (shandle *serveHandle) {
 		shandle = c.handle[uint(id)]
 	}
 	if shandle == nil {
-		c.debug(missingHandle{
-			Handle:    id,
-			MaxHandle: fuse.HandleID(len(c.handle)),
-		})
+		if c.debug != nil {
+			c.debug(missingHandle{
+				Handle:    id,
+				MaxHandle: fuse.HandleID(len(c.handle)),
+			})
+		}
 	}
 	return
 }
@@ -768,11 +774,13 @@ func (c *Server) serve(r fuse.Request) {
 		ctx = c.context(ctx, r)
 	}
 
-	c.debug(request{
-		Op:      opName(r),
-		Request: r.Hdr(),
-		In:      r,
-	})
+	if c.debug != nil {
+		c.debug(request{
+			Op:      opName(r),
+			Request: r.Hdr(),
+			In:      r,
+		})
+	}
 	var node Node
 	var snode *serveNode
 	c.meta.Lock()
@@ -783,17 +791,19 @@ func (c *Server) serve(r fuse.Request) {
 		}
 		if snode == nil {
 			c.meta.Unlock()
-			c.debug(response{
-				Op:      opName(r),
-				Request: logResponseHeader{ID: hdr.ID},
-				Error:   fuse.ESTALE.ErrnoName(),
-				// this is the only place that sets both Error and
-				// Out; not sure if i want to do that; might get rid
-				// of len(c.node) things altogether
-				Out: logMissingNode{
-					MaxNode: fuse.NodeID(len(c.node)),
-				},
-			})
+			if c.debug != nil {
+				c.debug(response{
+					Op:      opName(r),
+					Request: logResponseHeader{ID: hdr.ID},
+					Error:   fuse.ESTALE.ErrnoName(),
+					// this is the only place that sets both Error and
+					// Out; not sure if i want to do that; might get rid
+					// of len(c.node) things altogether
+					Out: logMissingNode{
+						MaxNode: fuse.NodeID(len(c.node)),
+					},
+				})
+			}
 			r.RespondError(fuse.ESTALE)
 			return
 		}
@@ -834,7 +844,9 @@ func (c *Server) serve(r fuse.Request) {
 		} else {
 			msg.Out = resp
 		}
-		c.debug(msg)
+		if c.debug != nil {
+			c.debug(msg)
+		}
 
 		c.meta.Lock()
 		delete(c.req, hdr.ID)
@@ -989,10 +1001,12 @@ func (c *Server) handleRequest(ctx context.Context, node Node, snode *serveNode,
 		}
 		c.meta.Unlock()
 		if oldNode == nil {
-			c.debug(logLinkRequestOldNodeNotFound{
-				Request: r.Hdr(),
-				In:      r,
-			})
+			if c.debug != nil {
+				c.debug(logLinkRequestOldNodeNotFound{
+					Request: r.Hdr(),
+					In:      r,
+				})
+			}
 			return fuse.EIO
 		}
 		n2, err := n.Link(ctx, r, oldNode.node)
@@ -1314,10 +1328,12 @@ func (c *Server) handleRequest(ctx context.Context, node Node, snode *serveNode,
 		}
 		c.meta.Unlock()
 		if newDirNode == nil {
-			c.debug(renameNewDirNodeNotFound{
-				Request: r.Hdr(),
-				In:      r,
-			})
+			if c.debug != nil {
+				c.debug(renameNewDirNodeNotFound{
+					Request: r.Hdr(),
+					In:      r,
+				})
+			}
 			return fuse.EIO
 		}
 		n, ok := node.(NodeRenamer)

--- a/fs/serve.go
+++ b/fs/serve.go
@@ -345,7 +345,7 @@ type Config struct {
 func New(conn *fuse.Conn, config *Config) *Server {
 	s := &Server{
 		conn:         conn,
-		req:          map[fuse.RequestID]*serveRequest{},
+		req:          map[fuse.RequestID]func(){},
 		nodeRef:      map[Node]fuse.NodeID{},
 		dynamicInode: GenerateDynamicInode,
 	}
@@ -371,7 +371,7 @@ type Server struct {
 
 	// state, protected by meta
 	meta       sync.Mutex
-	req        map[fuse.RequestID]*serveRequest
+	req        map[fuse.RequestID]func() // map request to cancel functions
 	node       []*serveNode
 	nodeRef    map[Node]fuse.NodeID
 	handle     []*serveHandle
@@ -435,11 +435,6 @@ func Serve(c *fuse.Conn, fs FS) error {
 }
 
 type nothing struct{}
-
-type serveRequest struct {
-	Request fuse.Request
-	cancel  func()
-}
 
 type serveNode struct {
 	inode      uint64
@@ -773,8 +768,6 @@ func (c *Server) serve(r fuse.Request) {
 		ctx = c.context(ctx, r)
 	}
 
-	req := &serveRequest{Request: r, cancel: cancel}
-
 	c.debug(request{
 		Op:      opName(r),
 		Request: r.Hdr(),
@@ -813,7 +806,7 @@ func (c *Server) serve(r fuse.Request) {
 		//
 		// TODO this might have been because of missing done() calls
 	} else {
-		c.req[hdr.ID] = req
+		c.req[hdr.ID] = cancel
 	}
 	c.meta.Unlock()
 
@@ -1372,10 +1365,9 @@ func (c *Server) handleRequest(ctx context.Context, node Node, snode *serveNode,
 
 	case *fuse.InterruptRequest:
 		c.meta.Lock()
-		ireq := c.req[r.IntrID]
-		if ireq != nil && ireq.cancel != nil {
-			ireq.cancel()
-			ireq.cancel = nil
+		if cancel := c.req[r.IntrID]; cancel != nil {
+			cancel()
+			delete(c.req, r.IntrID)
 		}
 		c.meta.Unlock()
 		done(nil)

--- a/fs/serve_test.go
+++ b/fs/serve_test.go
@@ -2,6 +2,7 @@ package fs_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -22,7 +23,6 @@ import (
 	"bazil.org/fuse/fs/fstestutil/record"
 	"bazil.org/fuse/fuseutil"
 	"bazil.org/fuse/syscallx"
-	"golang.org/x/net/context"
 )
 
 // TO TEST:

--- a/fs/tree.go
+++ b/fs/tree.go
@@ -3,11 +3,10 @@
 package fs
 
 import (
+	"context"
 	"os"
 	pathpkg "path"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 import (

--- a/fuse.go
+++ b/fuse.go
@@ -622,7 +622,9 @@ func (c *Conn) ReadRequest() (Request, error) {
 	var req Request
 	switch m.hdr.Opcode {
 	default:
-		Debug(noOpcode{Opcode: m.hdr.Opcode})
+		if Debug != nil {
+			Debug(noOpcode{Opcode: m.hdr.Opcode})
+		}
 		goto unrecognized
 
 	case opLookup:
@@ -1075,7 +1077,9 @@ func (c *Conn) ReadRequest() (Request, error) {
 	return req, nil
 
 corrupt:
-	Debug(malformedMessage{})
+	if Debug != nil {
+		Debug(malformedMessage{})
+	}
 	putMessage(m)
 	return nil, fmt.Errorf("fuse: malformed message")
 
@@ -1121,7 +1125,7 @@ func (c *Conn) writeToKernel(msg []byte) error {
 	c.wio.RLock()
 	defer c.wio.RUnlock()
 	nn, err := syscall.Write(c.fd(), msg)
-	if err == nil && nn != len(msg) {
+	if err == nil && nn != len(msg) && Debug != nil {
 		Debug(bugShortKernelWrite{
 			Written: int64(nn),
 			Length:  int64(len(msg)),
@@ -1133,7 +1137,7 @@ func (c *Conn) writeToKernel(msg []byte) error {
 }
 
 func (c *Conn) respond(msg []byte) {
-	if err := c.writeToKernel(msg); err != nil {
+	if err := c.writeToKernel(msg); err != nil && Debug != nil {
 		Debug(bugKernelWriteError{
 			Error: errorString(err),
 			Stack: stack(),

--- a/options_daemon_timeout_test.go
+++ b/options_daemon_timeout_test.go
@@ -5,6 +5,7 @@
 package fuse_test
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"syscall"
@@ -14,7 +15,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
-	"golang.org/x/net/context"
 )
 
 type slowCreaterDir struct {

--- a/options_test.go
+++ b/options_test.go
@@ -1,6 +1,7 @@
 package fuse_test
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"syscall"
@@ -9,7 +10,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
-	"golang.org/x/net/context"
 )
 
 func init() {


### PR DESCRIPTION
This series of commits considerably improves performance on my machine (macOS), on a simple in-memory filesystem, using git clone to exercise the filesystem.

Before these commits, the git clone ran 5-x10x slower than the plain filesystem. After these commits, the performance is comparable.

Some runtime.MemStats stats, before these commits:

`TotalAlloc=302219702256 Mallocs=343942 Frees=342827 GCCPUFraction=0.199405`

After the first (readbuf) commit:

`TotalAlloc=43079832 Mallocs=198069 Frees=197442 GCCPUFraction=0.000560`

At the end of the commits:

`TotalAlloc=41499160 Mallocs=104432 Frees=103759 GCCPUFraction=0.000171`

The commits are mostly independent of each other.
