### PR TITLE
Better error message on load failure

### DIFF
--- a/mount_darwin.go
+++ b/mount_darwin.go
@@ -24,7 +24,7 @@ func loadOSXFUSE(bin string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
-	return err
+	return fmt.Errorf("Error loading fuse (%s): %s", bin, err)
 }
 
 func openOSXFUSEDev(devPrefix string) (*os.File, error) {


### PR DESCRIPTION
If there is an error executing load, include path to bin and context, otherwise the error message returned from mounting is just "exit status 255".