### PR TITLE
Add ENOSPC to available error codes.

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -341,6 +341,9 @@ const (
 	ERANGE  = Errno(syscall.ERANGE)
 	ENOTSUP = Errno(syscall.ENOTSUP)
 	EEXIST  = Errno(syscall.EEXIST)
+
+	// ENOSPC indicates that there is not enough space left on device.
+	ENOSPC = Errno(syscall.ENOSPC)
 )
 
 // DefaultErrno is the errno used when error returned does not
@@ -355,6 +358,7 @@ var errnoNames = map[Errno]string{
 	EPERM:  "EPERM",
 	EINTR:  "EINTR",
 	EEXIST: "EEXIST",
+	ENOSPC: "ENOSPC",
 }
 
 // Errno implements Error and ErrorNumber using a syscall.Errno.


### PR DESCRIPTION
This is needed to show a correct error message when disk is full.