### PR TITLE
Accept syscall.Errno directly in RespondError

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -392,7 +392,9 @@ func (e Errno) MarshalText() ([]byte, error) {
 
 func (h *Header) RespondError(err error) {
 	errno := DefaultErrno
-	if ferr, ok := err.(ErrorNumber); ok {
+	if eno, ok := err.(syscall.Errno); ok {
+		errno = Errno(eno)
+	} else if ferr, ok := err.(ErrorNumber); ok {
 		errno = ferr.Errno()
 	}
 	// FUSE uses negative errors!


### PR DESCRIPTION
Since 99% of the time, error returned from syscall would be used directly, this would prevent the need to wrap errors in Errno every time. Unless there is a reason errors shouldn't be passed directly?