### PR TITLE
Support time_gran and max_pages fuse options

### DIFF
--- a/fuse_darwin.go
+++ b/fuse_darwin.go
@@ -1,5 +1,8 @@
 package fuse
 
+// Max pages per fuse message.
+const maxPages = 32
+
 // Maximum file write size we are prepared to receive from the kernel.
 //
 // This value has to be >=16MB or OSXFUSE (3.4.0 observed) will

--- a/fuse_freebsd.go
+++ b/fuse_freebsd.go
@@ -1,6 +1,9 @@
 package fuse
 
+// Max pages per fuse message.
+const maxPages = 32
+
 // Maximum file write size we are prepared to receive from the kernel.
 //
 // This number is just a guess.
-const maxWrite = 128 * 1024
+const maxWrite = maxPages * 4096

--- a/fuse_kernel.go
+++ b/fuse_kernel.go
@@ -46,7 +46,7 @@ const (
 	protoVersionMinMajor = 7
 	protoVersionMinMinor = 8
 	protoVersionMaxMajor = 7
-	protoVersionMaxMinor = 12
+	protoVersionMaxMinor = 28
 )
 
 const (
@@ -273,6 +273,12 @@ const (
 	InitAsyncDIO        InitFlags = 1 << 15
 	InitWritebackCache  InitFlags = 1 << 16
 	InitNoOpenSupport   InitFlags = 1 << 17
+	InitParallelDirops  InitFlags = 1 << 18
+	InitHandleKillpriv  InitFlags = 1 << 19
+	InitPosixACL        InitFlags = 1 << 20
+	InitAbortError      InitFlags = 1 << 21
+	InitMaxPages        InitFlags = 1 << 22
+	InitCacheSymlinks   InitFlags = 1 << 23
 
 	InitCaseSensitive InitFlags = 1 << 29 // OS X only
 	InitVolRename     InitFlags = 1 << 30 // OS X only
@@ -303,6 +309,12 @@ var initFlagNames = []flagName{
 	{uint32(InitAsyncDIO), "InitAsyncDIO"},
 	{uint32(InitWritebackCache), "InitWritebackCache"},
 	{uint32(InitNoOpenSupport), "InitNoOpenSupport"},
+	{uint32(InitParallelDirops), "InitParallelDirops"},
+	{uint32(InitHandleKillpriv), "InitHandleKillpriv"},
+	{uint32(InitPosixACL), "InitPosixACL"},
+	{uint32(InitAbortError), "InitAbortError"},
+	{uint32(InitMaxPages), "InitMaxPages"},
+	{uint32(InitCacheSymlinks), "InitCacheSymlinks"},
 
 	{uint32(InitCaseSensitive), "InitCaseSensitive"},
 	{uint32(InitVolRename), "InitVolRename"},
@@ -706,8 +718,13 @@ type initOut struct {
 	Minor        uint32
 	MaxReadahead uint32
 	Flags        uint32
-	Unused       uint32
+	_            uint16
+	_            uint16
 	MaxWrite     uint32
+	TimeGran     uint32
+	MaxPages     uint16
+	_            uint16
+	_            [8]uint32
 }
 
 type interruptIn struct {

--- a/fuse_linux.go
+++ b/fuse_linux.go
@@ -1,7 +1,13 @@
 package fuse
 
+// Max pages per fuse message (FUSE_MAX_MAX_PAGES).
+const maxPages = 256
+
 // Maximum file write size we are prepared to receive from the kernel.
 //
 // Linux 4.2.0 has been observed to cap this value at 128kB
 // (FUSE_MAX_PAGES_PER_REQ=32, 4kB pages).
-const maxWrite = 128 * 1024
+//
+// Linux >= 4.20 allows up to FUSE_MAX_MAX_PAGES=256, but defaults to
+// FUSE_DEFAULT_MAX_PAGES_PER_REQ=32.
+const maxWrite = maxPages * 4096

--- a/options.go
+++ b/options.go
@@ -14,6 +14,7 @@ func dummyOption(conf *mountConfig) error {
 type mountConfig struct {
 	options          map[string]string
 	maxReadahead     uint32
+	timeGran         uint32
 	initFlags        InitFlags
 	osxfuseLocations []OSXFUSEPaths
 }
@@ -227,6 +228,16 @@ func AsyncRead() MountOption {
 func WritebackCache() MountOption {
 	return func(conf *mountConfig) error {
 		conf.initFlags |= InitWritebackCache
+		return nil
+	}
+}
+
+// TimeGran sets the granularity of timestamps in nanoseconds.
+//
+// Default is 1 nanosecond, must be power of 10.
+func TimeGran(n uint32) MountOption {
+	return func(conf *mountConfig) error {
+		conf.timeGran = n
 		return nil
 	}
 }


### PR DESCRIPTION
This updated the supported FUSE protocol from 7.12 to 7.28.

The time_gran field can be set to a multiple of one nanosecond, if the
timestamps of files has less than nanosecond precision. This avoids
mismatches when the kernel compares timestamps.

The max_pages feature raises the maximum size of a FUSE message from 32
to 256 pages on Linux >= 4.20. This affects both reads and writes.
To be able to read more than 128 KB in a single ReadOp, Direct I/O must
also be used, since the kernel otherwise splits the read into 128 KB
chunks and requests them asynchronously (if max_readahead is at least
128 KB, otherwise max_readahead is used, or 4 KB if it is disabled).