### PR TITLE
Make build noop on windows

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuse
 
 import "unsafe"

--- a/error_std.go
+++ b/error_std.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuse
 
 // There is very little commonality in extended attribute errors

--- a/fs/bench/bench_create_test.go
+++ b/fs/bench/bench_create_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package bench_test
 
 import (

--- a/fs/bench/bench_lookup_test.go
+++ b/fs/bench/bench_lookup_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package bench_test
 
 import (

--- a/fs/bench/bench_readwrite_test.go
+++ b/fs/bench/bench_readwrite_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package bench_test
 
 import (

--- a/fs/bench/helpers_test.go
+++ b/fs/bench/helpers_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package bench_test
 
 import (

--- a/fs/fs_windows.go
+++ b/fs/fs_windows.go
@@ -1,0 +1,1 @@
+package fs

--- a/fs/fstestutil/checkdir.go
+++ b/fs/fstestutil/checkdir.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fstestutil
 
 import (

--- a/fs/fstestutil/debug.go
+++ b/fs/fstestutil/debug.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fstestutil
 
 import (

--- a/fs/fstestutil/mounted.go
+++ b/fs/fstestutil/mounted.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fstestutil
 
 import (

--- a/fs/fstestutil/mountinfo.go
+++ b/fs/fstestutil/mountinfo.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fstestutil
 
 // MountInfo describes a mounted file system.

--- a/fs/fstestutil/testfs.go
+++ b/fs/fstestutil/testfs.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fstestutil
 
 import (

--- a/fs/serve.go
+++ b/fs/serve.go
@@ -1,3 +1,4 @@
+// +build !windows
 // FUSE service loop, for servers that wish to use it.
 
 package fs // import "bazil.org/fuse/fs"

--- a/fs/tree.go
+++ b/fs/tree.go
@@ -1,3 +1,4 @@
+// +build !windows
 // FUSE directory tree, for servers that wish to use it with the service loop.
 
 package fs

--- a/fuse.go
+++ b/fuse.go
@@ -1,3 +1,4 @@
+// +build !windows
 // See the file LICENSE for copyright and licensing information.
 
 // Adapted from Plan 9 from User Space's src/cmd/9pfuse/fuse.c,

--- a/fuse_kernel.go
+++ b/fuse_kernel.go
@@ -1,3 +1,4 @@
+// +build !windows
 // See the file LICENSE for copyright and licensing information.
 
 // Derived from FUSE's fuse_kernel.h, which carries this notice:

--- a/fuseutil/fuseutil.go
+++ b/fuseutil/fuseutil.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuseutil // import "bazil.org/fuse/fuseutil"
 
 import (

--- a/fuseutil/fuseutil_windows.go
+++ b/fuseutil/fuseutil_windows.go
@@ -1,0 +1,1 @@
+package fuseutil

--- a/options.go
+++ b/options.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuse
 
 import (

--- a/unmount.go
+++ b/unmount.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuse
 
 // Unmount tries to unmount the filesystem mounted at dir.

--- a/unmount_std.go
+++ b/unmount_std.go
@@ -1,4 +1,5 @@
 // +build !linux
+// +build !windows
 
 package fuse
 


### PR DESCRIPTION
First up thanks for the awesome library, been having lots of fun!

This is a simple change to fix up a problem I have but not sure if you'd want to take it or not. 

I'm building a bit of tooling which runs on multiple OS's. On Linux and OSX I'd like to offer a fuse filesystem using Bazil. 

To make this work my source files which use the lib have `// +build !windows` in them. The problem is that go still attempts to build the library as it is imported in the `go.mod`. 

What I've done is add some build flags to make the library build targeting windows. The build on windows produces nothing but this allows it to be imported in a binary build for all three platforms and the user can manage it's conditional use. 

Make any sense? If there is a better way to do this with come kind of conditional include in `go.mod` do let me know, I couldn't find anything that did quite what I wanted tho. 