### PR TITLE
Adds Ioctl support

### DIFF
--- a/fuse_kernel.go
+++ b/fuse_kernel.go
@@ -913,3 +913,30 @@ type pollOut struct {
 type notifyPollWakeupOut struct {
 	Kh uint64
 }
+
+type ioctlIn struct {
+	Fh      uint64
+	Flags   uint32
+	Cmd     uint32
+	Arg     uint64
+	InSize  uint32
+	OutSize uint32
+}
+
+type ioctlOut struct {
+	Result  int32
+	Flags   uint32
+	InIovs  uint32 // fuse servers cannot do unresticted ioctls so these are always 0
+	OutIovs uint32
+}
+
+type IoctlFlags uint32
+
+const (
+	IoctlCompat       IoctlFlags = 1 << 0 // 32bit compat ioctl on 64bit machine
+	IoctlUnrestricted IoctlFlags = 1 << 1 // not restricted to well-formed ioctls, retry allowed
+	IoctlRetry        IoctlFlags = 1 << 2 // retry with new iovecs
+	Ioctl32Bit        IoctlFlags = 1 << 3 // 32bit ioctl
+	IoctlDir          IoctlFlags = 1 << 4 // is a directory
+	IoctlCompatX32    IoctlFlags = 1 << 5 // x32 compat ioctl on 64bit machine (64bit time_t)
+)


### PR DESCRIPTION
Adds support for handling ioctl requests made to fuse. This implementation comes from looking at the fuse implementation to fill in the missing ioctl functionality. Note that fuse servers do not support "unrestricted" ioctls meaning that there is no utility in supporting the ioctl retry mechanism. That part of the protocol appears to be reserved for cuse based servers.

If it's useful to anyone I was using this C program to test out the functionality (although a similar automated test has been added with this PR)

```#include <stdio.h>
#include <stdint.h>

#include <fcntl.h>
#include <sys/ioctl.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <unistd.h>

#include <asm-generic/ioctl.h>

struct mydata {
  uint32_t a;
  uint32_t b;
  uint32_t c;
  uint32_t d;
};

int main(int argc, char** argv) {
  for (int i = 1; i < argc; i++) {
    int fd = open(argv[i], O_RDONLY);
    if (fd == -1) {
      perror("open failed");
      return 1;
    }

    struct mydata x = {
      1, 2, 3, 4
    };

    int cmd = _IOWR('h', 0, mydata);

    int res = ioctl(fd, cmd, &x);
    if (res == -1) {
      perror("ioctl failed");
      return 1;
    }
    printf("RESULT: %d\n", res);
    printf("x.a=%d\n", x.a);

    close(fd);
  }
  return 0;
}
```